### PR TITLE
Fix ref forwarding in reusable components

### DIFF
--- a/components/Group.tsx
+++ b/components/Group.tsx
@@ -4,6 +4,12 @@ import { View, ViewProps } from 'react-native'
 type GroupProps = ViewProps & {}
 
 export default forwardRef(function Group(props: GroupProps, ref): JSX.Element {
-  const { className, ...rest } = props
-  return <View className={`flex w-full items-center`} {...rest} />
+  const { className = '', ...rest } = props
+  return (
+    <View
+      ref={ref}
+      className={`flex w-full items-center ${className}`}
+      {...rest}
+    />
+  )
 })

--- a/components/ThemedPressable.tsx
+++ b/components/ThemedPressable.tsx
@@ -5,12 +5,18 @@ type ThemedPressableProps = PressableProps & {
   secondary?: boolean // set true if button is not the primary call to action
 }
 
-export default forwardRef(function ThemedPressable(props: ThemedPressableProps, ref): JSX.Element {
-  const { className, secondary = false, disabled, ...rest } = props
+export default forwardRef(function ThemedPressable(
+  props: ThemedPressableProps,
+  ref,
+): JSX.Element {
+  const { className = '', secondary = false, disabled, ...rest } = props
 
   return (
     <Pressable
-      className={`${secondary ? 'bg-mafiaDarkGray' : disabled ? 'bg-mafiaGray' : 'bg-mafiaRed'} flex w-full items-center rounded-lg p-3 ${className}`}
+      ref={ref}
+      className={`${
+        secondary ? 'bg-mafiaDarkGray' : disabled ? 'bg-mafiaGray' : 'bg-mafiaRed'
+      } flex w-full items-center rounded-lg p-3 ${className}`}
       disabled={disabled}
       {...rest}
     />


### PR DESCRIPTION
## Summary
- ensure ThemedPressable passes ref and className
- ensure Group passes ref and className

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cypress)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684351042c5c83208d22582aa7348e2e