### PR TITLE
Add onboarding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ The back-end is built with [Supabase](https://supabase.com/). Data such as playe
 
 - Testing: [Cypress](https://www.cypress.io/) E2E
 
+## Onboarding
+
+The following NPM scripts are available for running the project and its tests:
+
+| Script | Description |
+| --- | --- |
+| `npm start` | Launches the Expo development server. |
+| `npm run android` | Starts the app on an Android emulator or device. |
+| `npm run ios` | Starts the app on an iOS simulator. |
+| `npm run web` | Serves the web version of the app. |
+| `npm run start-test` | Builds the web bundle and serves it on port `8081` for tests. |
+| `npm run test` | Runs the Cypress end-to-end test suite. |
+| `npm run test-open` | Opens the Cypress interface for interactive testing. |
+| `npm run lint` | Runs the Expo linter on the project. |
+| `npm run build` | Exports a production web build. |
+| `npm run reset-project` | Resets cached build data and reinstalls dependencies. |
+
 ## Current Roadmap
 
 ### 1. Minimum Viable Product


### PR DESCRIPTION
## Summary
- add an onboarding section to list npm scripts and what they do

## Testing
- `pre-commit` failed: `Error: spawn Xvfb ENOENT`
- skipped tests because only documentation was changed

------
https://chatgpt.com/codex/tasks/task_e_686c24146fc0832098afebe4b2fe6a51