### PR TITLE
Update Expo to SDK 53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@supabase/supabase-js": "^2.43.4",
         "dotenv": "^8.6.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
-        "expo": "~51.0.31",
+        "expo": "~53.0.0",
         "expo-av": "~14.0.7",
         "expo-constants": "~16.0.2",
         "expo-font": "~12.0.9",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@supabase/supabase-js": "^2.43.4",
     "dotenv": "^8.6.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
-    "expo": "~51.0.31",
+    "expo": "~53.0.0",
     "expo-av": "~14.0.7",
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",


### PR DESCRIPTION
## Summary
- upgrade Expo SDK from 51 to 53

## Testing
- `npm run lint`
- `npm test` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686c2920ec448320b0c23a015dbdc082