### PR TITLE
Replace deprecated react-test-renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "devDependencies": {
         "@babel/core": "^7.24.7",
         "@types/react": "~18.2.45",
-        "@types/react-test-renderer": "^18.3.0",
+        "@testing-library/react-native": "^11.5.0",
         "cypress": "^13.12.0",
         "eslint": "^8.57.0",
         "eslint-config-expo": "^7.1.2",
@@ -51,7 +51,6 @@
         "pre-commit": "^1.2.2",
         "prettier": "^3.3.2",
         "prettier-plugin-tailwindcss": "^0.6.5",
-        "react-test-renderer": "18.2.0",
         "tailwindcss": "~3.3.2",
         "typescript": "~5.3.3"
       }
@@ -7033,16 +7032,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-test-renderer": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.3.0.tgz",
-      "integrity": "sha512-HW4MuEYxfDbOHQsVlY/XtOvNHftCVEPhJF2pQXXwcUiUF+Oyb0usgp48HSgpK5rt8m9KZb22yqOeZm+rrVG8gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -17324,28 +17313,6 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
-    },
-    "node_modules/react-test-renderer": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
-      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^18.2.0",
-        "react-shallow-renderer": "^16.15.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@babel/core": "^7.24.7",
     "@types/react": "~18.2.45",
-    "@types/react-test-renderer": "^18.3.0",
+    "@testing-library/react-native": "^11.5.0",
     "cypress": "^13.12.0",
     "eslint": "^8.57.0",
     "eslint-config-expo": "^7.1.2",
@@ -62,7 +62,6 @@
     "pre-commit": "^1.2.2",
     "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.6.5",
-    "react-test-renderer": "18.2.0",
     "tailwindcss": "~3.3.2",
     "typescript": "~5.3.3"
   },


### PR DESCRIPTION
## Summary
- replace `react-test-renderer` with `@testing-library/react-native`
- clean up lock file

## Testing
- `npm test` *(fails: missing Xvfb)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c2af27be0832082480d1a9ed28636