### PR TITLE
Upgrade to Expo SDK 53

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,7 +7,7 @@ import { AuthProvider } from '@/providers/AuthProvider'
 import colors from '../constants/colors'
 import * as SystemUI from 'expo-system-ui'
 
-// This makes it so native-wind styles also work on web. For some reason it was necessary even though I'm currently using Expo 51 which is greater than 45.
+// This makes it so native-wind styles also work on web. For some reason it was necessary even though I'm currently using Expo 53 which is greater than 45.
 // https://www.nativewind.dev/quick-starts/expo#expo-sdk-45
 NativeWindStyleSheet.setOutput({
   default: 'native',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@supabase/supabase-js": "^2.43.4",
         "dotenv": "^8.6.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
-        "expo": "~51.0.31",
+        "expo": "~53.0.0",
         "expo-av": "~14.0.7",
         "expo-constants": "~16.0.2",
         "expo-font": "~12.0.9",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@supabase/supabase-js": "^2.43.4",
     "dotenv": "^8.6.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
-    "expo": "~51.0.31",
+    "expo": "~53.0.0",
     "expo-av": "~14.0.7",
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",


### PR DESCRIPTION
## Summary
- bump Expo SDK from 51 to 53 in package files
- update comment in `_layout.tsx` that mentioned the old SDK

## Testing
- `npm run lint`
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686c4245245483209e7e2b78c4337e8d