### PR TITLE
Fix Cypress config with ts-node project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@babel/core": "^7.24.7",
         "@types/react": "~19.0.10",
         "@types/react-test-renderer": "^18.3.0",
+        "cross-env": "^7.0.2",
         "cypress": "^13.12.0",
         "eslint": "^8.57.0",
         "eslint-config-expo": "~9.2.0",
@@ -5846,6 +5847,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "TS_NODE_PROJECT=tsconfig.node.json npx cypress run",
+    "test": "cross-env TS_NODE_PROJECT=tsconfig.node.json npx cypress run",
     "test-open": "npx cypress open",
     "lint": "expo lint",
     "build": "npx expo export -p web"
@@ -55,6 +55,7 @@
     "@types/react": "~19.0.10",
     "@types/react-test-renderer": "^18.3.0",
     "cypress": "^13.12.0",
+    "cross-env": "^7.0.2",
     "eslint": "^8.57.0",
     "eslint-config-expo": "~9.2.0",
     "eslint-plugin-cypress": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "npx cypress run",
+    "test": "TS_NODE_PROJECT=tsconfig.node.json npx cypress run",
     "test-open": "npx cypress open",
     "lint": "expo lint",
     "build": "npx expo export -p web"

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "node16",
+    "module": "commonjs",
+    "baseUrl": ".",
+    "types": ["node"],
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- specify a Node-focused tsconfig for Cypress
- use that tsconfig when running tests

## Testing
- `npm run lint`
- `npm run test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686d55ab731083208e72e1ce2f323790