### PR TITLE
Fix login warning with navigation

### DIFF
--- a/helpers/resetRouter.ts
+++ b/helpers/resetRouter.ts
@@ -6,7 +6,10 @@ const resetRouter = (
   initialRoute: string,
 ) => {
   // this is a bit hacky but seems to currently be the best solution since expo doesn't offer any kind of navigation.reset() function
-  navigation.dispatch(StackActions.popToTop())
+  // 'POP_TO_TOP' can throw a warning if there is no screen to go back to, so only dispatch when possible
+  if (navigation.canGoBack()) {
+    navigation.dispatch(StackActions.popToTop())
+  }
   router.replace(initialRoute)
 }
 


### PR DESCRIPTION
## Summary
- avoid dispatching `POP_TO_TOP` when there's no back stack in `resetRouter`

## Testing
- `npm run lint`
- `npm test` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_686db642741483208d33042c951703e6