### PR TITLE
Fix AuthProvider loading effect

### DIFF
--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -35,28 +35,34 @@ export function AuthProvider(props: PropsWithChildren) {
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
-    setLoading(true)
-    // Tells Supabase Auth to continuously refresh the session automatically if
-    // the app is in the foreground. When this is added, you will continue to receive
-    // `onAuthStateChange` events with the `TOKEN_REFRESHED` or `SIGNED_OUT` event
-    // if the user's session is terminated. This should only be registered once.
+    let ignore = false
 
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
-      setLoading(false)
-    })
-
-    supabase.auth
-      .getSession()
-      .then(({ data: { session } }) => {
+      if (!ignore) {
         setSession(session)
         setLoading(false)
-      })
-      .catch(() => setLoading(false))
+      }
+    })
+
+    const initialize = async () => {
+      setLoading(true)
+
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession()
+        if (!ignore) setSession(session)
+      } finally {
+        if (!ignore) setLoading(false)
+      }
+    }
+
+    initialize()
 
     return () => {
+      ignore = true
       subscription.unsubscribe()
     }
   }, [])

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -32,19 +32,11 @@ export function AuthProvider(props: PropsWithChildren) {
   const router = useRouter()
   const navigation = useNavigation()
   const [session, setSession] = useState<Session | null>(null)
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     let ignore = false
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (!ignore) {
-        setSession(session)
-        setLoading(false)
-      }
-    })
+    let subscription: { unsubscribe: () => void } | null = null
 
     const initialize = async () => {
       setLoading(true)
@@ -54,6 +46,14 @@ export function AuthProvider(props: PropsWithChildren) {
           data: { session },
         } = await supabase.auth.getSession()
         if (!ignore) setSession(session)
+
+        const {
+          data: { subscription: sub },
+        } = supabase.auth.onAuthStateChange((_event, sess) => {
+          if (!ignore) setSession(sess)
+        })
+
+        subscription = sub
       } finally {
         if (!ignore) setLoading(false)
       }
@@ -63,7 +63,7 @@ export function AuthProvider(props: PropsWithChildren) {
 
     return () => {
       ignore = true
-      subscription.unsubscribe()
+      subscription?.unsubscribe()
     }
   }, [])
 

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -40,18 +40,25 @@ export function AuthProvider(props: PropsWithChildren) {
     // the app is in the foreground. When this is added, you will continue to receive
     // `onAuthStateChange` events with the `TOKEN_REFRESHED` or `SIGNED_OUT` event
     // if the user's session is terminated. This should only be registered once.
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+      setLoading(false)
+    })
+
     supabase.auth
       .getSession()
       .then(({ data: { session } }) => {
         setSession(session)
+        setLoading(false)
       })
-      .then(() => setLoading(false))
+      .catch(() => setLoading(false))
 
-    supabase.auth.onAuthStateChange((_event, session) => {
-      setLoading(true)
-      setSession(session)
-      setLoading(false)
-    })
+    return () => {
+      subscription.unsubscribe()
+    }
   }, [])
 
   return (

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -35,35 +35,29 @@ export function AuthProvider(props: PropsWithChildren) {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    let ignore = false
-    let subscription: { unsubscribe: () => void } | null = null
+    let isMounted = true
 
-    const initialize = async () => {
-      setLoading(true)
-
-      try {
-        const {
-          data: { session },
-        } = await supabase.auth.getSession()
-        if (!ignore) setSession(session)
-
-        const {
-          data: { subscription: sub },
-        } = supabase.auth.onAuthStateChange((_event, sess) => {
-          if (!ignore) setSession(sess)
-        })
-
-        subscription = sub
-      } finally {
-        if (!ignore) setLoading(false)
+    const getInitialSession = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      if (isMounted) {
+        setSession(session)
+        setLoading(false)
       }
     }
 
-    initialize()
+    getInitialSession()
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, sess) => {
+      if (isMounted) setSession(sess)
+    })
 
     return () => {
-      ignore = true
-      subscription?.unsubscribe()
+      isMounted = false
+      subscription.unsubscribe()
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- avoid dangling auth state listener
- update loading logic

## Testing
- `npm run lint`
- `npm test` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686db631f0088320b29566bbbc67a75d