### PR TITLE
Fix loading spinner on authenticated reload

### DIFF
--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -45,13 +45,19 @@ export function AuthProvider(props: PropsWithChildren) {
       .then(({ data: { session } }) => {
         setSession(session)
       })
-      .then(() => setLoading(false))
+      .finally(() => setLoading(false))
 
-    supabase.auth.onAuthStateChange((_event, session) => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
       setLoading(true)
       setSession(session)
       setLoading(false)
     })
+
+    return () => {
+      subscription.unsubscribe()
+    }
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- prevent auth listener leak and ensure loading resolves by unsubscribing from Supabase auth

## Testing
- `npm run lint`
- `npm test` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_686dc2edb7c883209d24915617ccbae4